### PR TITLE
Flip two bits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "superslice"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Alkis Evlogimenos <alkis@evlogimenos.com>"]
 description = "Extensions for slices"
 homepage = "https://github.com/alkis/superslice-rs"


### PR DESCRIPTION
Hi! README currently suggest using `1.0.0` : 

![image](https://user-images.githubusercontent.com/1711539/42722640-237d30b0-8758-11e8-8b11-7c9265462e54.png)

Initially, I wanted to just fix the readme, but maybe let's just do 1.0.0? :) 